### PR TITLE
Postgres release 2 is not available anymore, added a variable for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ None.
 
 Role Variables
 --------------
-`postgres_version: 9.4 #default`
+`postgres_version: 9.4 #default`  
 `postgres_release: 3 #default`
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ None.
 Role Variables
 --------------
 `postgres_version: 9.4 #default`
+`postgres_release: 3 #default`
 
 Dependencies
 ------------
@@ -28,7 +29,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: database_servers
       roles:
-         - { role: tjtoml.postgresql, postgres_version: 9.4 }
+         - { role: tjtoml.postgresql, postgres_version: 9.4, postgres_release: 3 }
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for postgresql
 postgres_version: 9.4
+postgres_release: 4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for postgresql
 postgres_version: 9.4
-postgres_release: 4
+postgres_release: 3

--- a/tasks/CentOS-6.yml
+++ b/tasks/CentOS-6.yml
@@ -1,25 +1,13 @@
 ---
-- name: Check to see if the second PostGres release is out
-  uri:
-    url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-  register: repo_test
-  ignore_errors: yes
-  no_log: true
-
-- name: Install postgres RPM repo (first release)
+- name: Install postgres RPM repo
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-1.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{ postgres_version }}-{{postgres_release }}.noarch.rpm"
     state: present
-  when: repo_test.status == 404
-
-- name: Install postgres RPM repo (Second release)
-  yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-    state: present
-  when: repo_test.status == 200
 
 - name: Install postgres packages and other deps
-  yum: name={{item}} state=present
+  yum: 
+    name: {{item}} 
+    state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server
     - postgresql{{ postgres_version | replace('.', '') }}-contrib

--- a/tasks/CentOS-6.yml
+++ b/tasks/CentOS-6.yml
@@ -6,7 +6,7 @@
 
 - name: Install postgres packages and other deps
   yum: 
-    name: {{item}} 
+    name: "{{item}}" 
     state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server

--- a/tasks/CentOS-7.yml
+++ b/tasks/CentOS-7.yml
@@ -6,7 +6,7 @@
 
 - name: Install postgres packages and other deps
   yum: 
-    name: {{item}} 
+    name: "{{item}}" 
     state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server

--- a/tasks/CentOS-7.yml
+++ b/tasks/CentOS-7.yml
@@ -1,25 +1,13 @@
 ---
-- name: Check to see if the second PostGres release is out
-  uri:
-    url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-  register: repo_test
-  ignore_errors: yes
-  no_log: true
-
-- name: Install postgres RPM repo (first release)
+- name: Install postgres RPM repo
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-1.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{ postgres_version }}-{{ postgres_release }}.noarch.rpm"
     state: present
-  when: repo_test.status == 404
-
-- name: Install postgres RPM repo (Second release)
-  yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-    state: present
-  when: repo_test.status == 200
 
 - name: Install postgres packages and other deps
-  yum: name={{item}} state=present
+  yum: 
+    name: {{item}} 
+    state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server
     - postgresql{{ postgres_version | replace('.', '') }}-contrib

--- a/tasks/Debian-7.yml
+++ b/tasks/Debian-7.yml
@@ -12,7 +12,7 @@
 
 - name: Ensure packages are installed
   apt: 
-    name: {{item}}
+    name: "{{item}}"
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Debian-7.yml
+++ b/tasks/Debian-7.yml
@@ -11,7 +11,8 @@
     update_cache: yes
 
 - name: Ensure packages are installed
-  apt: name={{item}}
+  apt: 
+    name: {{item}}
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Debian-8.yml
+++ b/tasks/Debian-8.yml
@@ -12,7 +12,7 @@
 
 - name: Ensure packages are installed
   apt: 
-    name: {{item}}
+    name: "{{item}}"
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Debian-8.yml
+++ b/tasks/Debian-8.yml
@@ -11,7 +11,8 @@
     update_cache: yes
 
 - name: Ensure packages are installed
-  apt: name={{item}}
+  apt: 
+    name: {{item}}
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Debian-9.yml
+++ b/tasks/Debian-9.yml
@@ -22,7 +22,7 @@
 
 - name: Ensure packages are installed
   apt: 
-    name: {{item}}
+    name: "{{item}}"
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Debian-9.yml
+++ b/tasks/Debian-9.yml
@@ -21,7 +21,8 @@
     update_cache: yes
 
 - name: Ensure packages are installed
-  apt: name={{item}}
+  apt: 
+    name: {{item}}
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/RedHat-6.yml
+++ b/tasks/RedHat-6.yml
@@ -6,7 +6,7 @@
 
 - name: Install postgres packages and other deps
   yum: 
-    name: {{item}} 
+    name: "{{item}}" 
     state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server

--- a/tasks/RedHat-6.yml
+++ b/tasks/RedHat-6.yml
@@ -1,25 +1,13 @@
 ---
-- name: Check to see if the second PostGres release is out
-  uri:
-    url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-  register: repo_test
-  ignore_errors: yes
-  no_log: true
-
-- name: Install postgres RPM repo (first release)
+- name: Install postgres RPM repo
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-1.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{ postgres_version }}-{{ postgres_release }}.noarch.rpm"
     state: present
-  when: repo_test.status == 404
-
-- name: Install postgres RPM repo (Second release)
-  yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-    state: present
-  when: repo_test.status == 200
 
 - name: Install postgres packages and other deps
-  yum: name={{item}} state=present
+  yum: 
+    name: {{item}} 
+    state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server
     - postgresql{{ postgres_version | replace('.', '') }}-contrib

--- a/tasks/RedHat-7.yml
+++ b/tasks/RedHat-7.yml
@@ -1,25 +1,13 @@
 ---
-- name: Check to see if the second PostGres release is out
-  uri:
-    url: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-  register: repo_test
-  ignore_errors: yes
-  no_log: true
-
-- name: Install postgres RPM repo (first release)
+- name: Install postgres RPM repo
   yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-1.noarch.rpm"
+    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{ postgres_version }}-{{ postgres_release }}.noarch.rpm"
     state: present
-  when: repo_test.status == 404
-
-- name: Install postgres RPM repo (Second release)
-  yum:
-    name: "https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture | lower }}/pgdg-{{ ansible_distribution | lower }}{{ postgres_version | replace('.', '') }}-{{postgres_version }}-2.noarch.rpm"
-    state: present
-  when: repo_test.status == 200
 
 - name: Install postgres packages and other deps
-  yum: name={{item}} state=present
+  yum: 
+    name: {{item}}
+    state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server
     - postgresql{{ postgres_version | replace('.', '') }}-contrib

--- a/tasks/RedHat-7.yml
+++ b/tasks/RedHat-7.yml
@@ -6,7 +6,7 @@
 
 - name: Install postgres packages and other deps
   yum: 
-    name: {{item}}
+    name: "{{item}}"
     state: present
   with_items:
     - postgresql{{ postgres_version | replace('.', '') }}-server

--- a/tasks/Ubuntu-14.yml
+++ b/tasks/Ubuntu-14.yml
@@ -12,7 +12,7 @@
 
 - name: Ensure packages are installed
   apt: 
-    name: {{item}}
+    name: "{{item}}"
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Ubuntu-14.yml
+++ b/tasks/Ubuntu-14.yml
@@ -11,7 +11,8 @@
     update_cache: yes
 
 - name: Ensure packages are installed
-  apt: name={{item}}
+  apt: 
+    name: {{item}}
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Ubuntu-16.yml
+++ b/tasks/Ubuntu-16.yml
@@ -27,7 +27,8 @@
     update_cache: yes
 
 - name: Ensure packages are installed
-  apt: name={{item}}
+  apt: 
+    name: {{item}}
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev

--- a/tasks/Ubuntu-16.yml
+++ b/tasks/Ubuntu-16.yml
@@ -28,7 +28,7 @@
 
 - name: Ensure packages are installed
   apt: 
-    name: {{item}}
+    name: "{{item}}"
   with_items:
     - postgresql-{{ postgres_version }}
     - libpq-dev


### PR DESCRIPTION
Currently the playbook fails to install because the postgres 9.4 release 2 is not available anymore. I added the variable postgres_release so users can set it manually if a new release comes out. 
I also adapted some of the yml code according to ansible-lint best practices.